### PR TITLE
Implement API services and use them in settings and pets

### DIFF
--- a/src/components/MyPets.tsx
+++ b/src/components/MyPets.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Plus, Heart, Edit, Trash2, X, Camera, Shield, Stethoscope } from 'lucide-react';
 import { Pet } from '../types';
 import { mockPets } from '../data/mockData';
+import { addPet, updatePet } from '../services/petService';
 
 interface MyPetsProps {
   isOpen: boolean;
@@ -38,18 +39,27 @@ const MyPets: React.FC<MyPetsProps> = ({ isOpen, onClose }) => {
     }
   };
 
-  const handleSavePet = () => {
-    if (editingPet) {
-      setPets(prev => prev.map(pet => pet.id === editingPet.id ? { ...pet, ...formData } : pet));
-    } else {
-      const newPet: Pet = {
-        ...formData as Pet,
-        id: Date.now().toString(),
-        ownerId: '1'
-      };
-      setPets(prev => [...prev, newPet]);
+  const handleSavePet = async () => {
+    try {
+      if (editingPet) {
+        const updated: Pet = { ...editingPet, ...(formData as Pet) };
+        await updatePet(updated);
+        setPets(prev => prev.map(pet => pet.id === editingPet.id ? updated : pet));
+        alert('Pet atualizado com sucesso!');
+      } else {
+        const newPet: Pet = {
+          ...(formData as Pet),
+          id: Date.now().toString(),
+          ownerId: '1'
+        };
+        await addPet(newPet);
+        setPets(prev => [...prev, newPet]);
+        alert('Pet adicionado com sucesso!');
+      }
+      resetForm();
+    } catch (err) {
+      alert('Erro ao salvar pet');
     }
-    resetForm();
   };
 
   const handleDeletePet = (petId: string) => {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Settings as SettingsIcon, Bell, Shield, Eye, Mail, Smartphone, X, Save } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { saveSettings } from '../services/settingsService';
 
 interface SettingsProps {
   isOpen: boolean;
@@ -53,10 +54,15 @@ const Settings: React.FC<SettingsProps> = ({ isOpen, onClose }) => {
     }));
   };
 
-  const handleSave = () => {
-    // Aqui você salvaria as configurações no backend
-    console.log('Saving settings:', settings);
-    onClose();
+  const handleSave = async () => {
+    if (!user) return;
+    try {
+      await saveSettings(user.id, settings);
+      alert('Configurações salvas com sucesso!');
+      onClose();
+    } catch (err) {
+      alert('Erro ao salvar configurações');
+    }
   };
 
   return (

--- a/src/services/petService.ts
+++ b/src/services/petService.ts
@@ -1,0 +1,35 @@
+import { Pet } from '../types';
+
+const API_BASE = '/api';
+
+export async function addPet(pet: Pet) {
+  const response = await fetch(`${API_BASE}/pets`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(pet)
+  });
+
+  if (!response.ok) {
+    throw new Error('Falha ao adicionar pet');
+  }
+
+  return response.json();
+}
+
+export async function updatePet(pet: Pet) {
+  const response = await fetch(`${API_BASE}/pets/${pet.id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(pet)
+  });
+
+  if (!response.ok) {
+    throw new Error('Falha ao editar pet');
+  }
+
+  return response.json();
+}

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -1,0 +1,38 @@
+export interface UserSettings {
+  notifications: {
+    email: boolean;
+    sms: boolean;
+    push: boolean;
+    bookingUpdates: boolean;
+    promotions: boolean;
+    reminders: boolean;
+  };
+  privacy: {
+    showPhone: boolean;
+    showEmail: boolean;
+    profileVisibility: 'public' | 'private';
+    allowMessages: boolean;
+  };
+  security: {
+    twoFactor: boolean;
+    loginAlerts: boolean;
+  };
+}
+
+const API_BASE = '/api';
+
+export async function saveSettings(userId: string, settings: UserSettings) {
+  const response = await fetch(`${API_BASE}/users/${userId}/settings`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(settings)
+  });
+
+  if (!response.ok) {
+    throw new Error('Falha ao salvar configurações');
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add services to persist user settings and pets via API
- use `saveSettings` to persist settings changes with feedback
- use `addPet` and `updatePet` when saving pets and display status

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6845158455dc8326b1218635066684e4