### PR TITLE
Add password recovery flow

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { X, Mail, Lock, User, Phone, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import ResetPasswordModal from './ResetPasswordModal';
 
 interface AuthModalProps {
   isOpen: boolean;
@@ -11,6 +12,7 @@ interface AuthModalProps {
 const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, initialMode = 'login' }) => {
   const [mode, setMode] = useState<'login' | 'register'>(initialMode);
   const [showPassword, setShowPassword] = useState(false);
+  const [resetOpen, setResetOpen] = useState(false);
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -91,6 +93,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, initialMode = 'l
   };
 
   return (
+    <>
     <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
       <div className="bg-white rounded-2xl max-w-md w-full max-h-[90vh] overflow-y-auto">
         {/* Header */}
@@ -270,7 +273,11 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, initialMode = 'l
 
           {mode === 'login' && (
             <div className="mt-4 text-center">
-              <button className="text-primary-600 hover:text-primary-700 text-sm font-medium">
+              <button
+                type="button"
+                onClick={() => setResetOpen(true)}
+                className="text-primary-600 hover:text-primary-700 text-sm font-medium"
+              >
                 Esqueceu sua senha?
               </button>
             </div>
@@ -293,6 +300,8 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, initialMode = 'l
         </div>
       </div>
     </div>
+    <ResetPasswordModal isOpen={resetOpen} onClose={() => setResetOpen(false)} />
+    </>
   );
 };
 

--- a/src/components/ResetPasswordModal.tsx
+++ b/src/components/ResetPasswordModal.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { X, Mail } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
+
+interface ResetPasswordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const ResetPasswordModal: React.FC<ResetPasswordModalProps> = ({ isOpen, onClose }) => {
+  const { forgotPassword, isLoading } = useAuth();
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setMessage('');
+    const success = await forgotPassword(email);
+    if (success) {
+      setMessage('Se o e-mail estiver cadastrado, você receber\u00e1 um link para redefinir sua senha.');
+    } else {
+      setError('N\u00e3o foi poss\u00edvel enviar o e-mail de recupera\u00e7\u00e3o. Tente novamente.');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl max-w-md w-full overflow-y-auto">
+        <div className="sticky top-0 bg-white border-b border-gray-200 p-6 flex justify-between items-center rounded-t-2xl">
+          <h2 className="text-2xl font-bold text-gray-900">Recuperar Senha</h2>
+          <button onClick={onClose} className="p-2 hover:bg-gray-100 rounded-lg transition-colors">
+            <X className="h-6 w-6" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Digite seu e-mail</label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
+              <input
+                type="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full pl-10 pr-4 py-3 border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all border-gray-300"
+                placeholder="seu@email.com"
+              />
+            </div>
+          </div>
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+          {message && <p className="text-green-600 text-sm">{message}</p>}
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full bg-primary-600 text-white py-3 px-4 rounded-lg hover:bg-primary-700 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isLoading ? 'Enviando...' : 'Enviar recupera\u00e7\u00e3o'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ResetPasswordModal;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ interface AuthContextType {
   user: User | null;
   login: (email: string, password: string) => Promise<boolean>;
   register: (userData: RegisterData) => Promise<boolean>;
+  forgotPassword: (email: string) => Promise<boolean>;
   logout: () => void;
   isLoading: boolean;
 }
@@ -86,13 +87,31 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return true;
   };
 
+  const forgotPassword = async (email: string): Promise<boolean> => {
+    setIsLoading(true);
+    try {
+      const response = await fetch('/api/password/forgot', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+      setIsLoading(false);
+      return response.ok;
+    } catch {
+      setIsLoading(false);
+      return false;
+    }
+  };
+
   const logout = () => {
     setUser(null);
     localStorage.removeItem('dogsinn_user');
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, register, logout, isLoading }}>
+    <AuthContext.Provider
+      value={{ user, login, register, forgotPassword, logout, isLoading }}
+    >
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add password recovery modal for requesting resets
- connect AuthContext with backend endpoint
- link "Esqueceu sua senha?" to open password recovery modal

## Testing
- `npm run build`
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68451586a8d88326b6d0fda9f7affc92