### PR TITLE
Add CI workflow with SSH deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Deploy
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.SSH_PORT }}
+          script: |
+            cd ${{ secrets.DEPLOY_PATH }}
+            git pull
+            npm ci
+            npm run build
+            pm2 restart all
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Dogs Inn Cuiabá
+
+This project uses GitHub Actions for continuous integration and deployment.
+
+## CI workflow
+
+The workflow defined in `.github/workflows/ci.yml` installs dependencies, builds the project and deploys it to a remote server via SSH.
+
+### Required repository secrets
+
+The following secrets must be added to the repository settings for deployment to succeed:
+
+- `SSH_HOST` &mdash; address of the server.
+- `SSH_USER` &mdash; SSH user used to connect.
+- `SSH_KEY` &mdash; private key for authentication.
+- `SSH_PORT` &mdash; SSH port (default is 22).
+- `DEPLOY_PATH` &mdash; directory on the server where the repository should be deployed.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy using ssh-action
- document required secrets in the README

## Testing
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_68451b6b70848326b83b78a8b9dd80d7