### PR TITLE
Add README with secrets guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Project Dog Inn
+
+This repository contains the frontend and backend code for the Dog Inn application.
+
+## Secrets Management
+
+No sensitive tokens or credentials are included in this repository. Deployment keys and other secrets should be stored in [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) and accessed via the CI/CD pipeline.
+
+Create a `.env` file locally for environment variables, and ensure it is not committed to the repository.


### PR DESCRIPTION
## Summary
- document secrets usage in `README.md`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68451b8ef6fc8326b34ae7e9b69815ad